### PR TITLE
feat: add Services section with bilingual, slop-checked copy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "./contexts/LanguageContext";
 import { translations } from "./i18n/translations";
 
 const Experience = lazy(() => import("./components/Experience"));
+const Services = lazy(() => import("./components/Services"));
 const Projects = lazy(() => import("./components/Projects"));
 const Skills = lazy(() => import("./components/Skills"));
 const GitHubActivity = lazy(() => import("./components/GitHubActivity"));
@@ -23,7 +24,7 @@ export default function App() {
 
   // ScrollSpy via IntersectionObserver — avoids forced reflow from offsetTop reads
   useEffect(() => {
-    const sectionIds = ["hero", "about", "experience", "projects", "skills", "github", "contact"];
+    const sectionIds = ["hero", "about", "services", "experience", "projects", "skills", "github", "contact"];
     const observed = new Set<string>();
     const visibleSections = new Map<string, number>();
 
@@ -171,6 +172,7 @@ export default function App() {
 
         {/* Below-the-fold sections: lazy-loaded to reduce main-thread work */}
         <Suspense fallback={null}>
+          <Services />
           <Experience />
           <Projects />
           <Skills />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -20,6 +20,7 @@ export default function Navbar({ activeSection, onNavigate }: NavbarProps) {
   const navLinks = [
     { label: t.navHome, id: "hero" },
     { label: t.navAbout, id: "about" },
+    { label: t.navServices, id: "services" },
     { label: t.navExperience, id: "experience" },
     { label: t.navProjects, id: "projects" },
     { label: t.navSkills, id: "skills" },

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,0 +1,121 @@
+import { motion } from "motion/react";
+import { Globe, LayoutDashboard, Gauge, Wrench, Linkedin, ArrowUpRight, ExternalLink } from "lucide-react";
+import { SERVICES, STATS, LINKEDIN_URL } from "../data";
+import { Service } from "../types";
+import { useLanguage } from "../contexts/LanguageContext";
+import { translations } from "../i18n/translations";
+
+const renderServiceIcon = (icon: Service["icon"], className = "w-10 h-10") => {
+  switch (icon) {
+    case "website": return <Globe className={className} />;
+    case "webapp": return <LayoutDashboard className={className} />;
+    case "redesign": return <Gauge className={className} />;
+    case "maintenance": return <Wrench className={className} />;
+    default: return <Globe className={className} />;
+  }
+};
+
+const scrollToContact = () => {
+  const el = document.getElementById("contact");
+  if (el) el.scrollIntoView({ behavior: "smooth" });
+};
+
+export default function Services() {
+  const { lang } = useLanguage();
+  const t = translations[lang];
+
+  const proofStats = [STATS[2], STATS[1], STATS[3]];
+
+  return (
+    <section id="services" className="relative py-24 md:py-32 overflow-hidden border-t scroll-mt-20" style={{ backgroundColor: "var(--color-bg-primary)", borderColor: "var(--color-border-primary)" }}>
+      <div className="max-w-7xl mx-auto px-6 md:px-12 relative z-10">
+        <div className="mb-20 flex flex-col md:flex-row md:items-end justify-between gap-6">
+          <div>
+            <span className="block font-mono text-[10px] tracking-[0.3em] uppercase mb-3" style={{ color: "var(--color-text-muted)" }}>{t.svcSection}</span>
+            <h2 className="font-display font-black text-4xl md:text-5xl lg:text-6xl tracking-tight leading-none" style={{ color: "var(--color-text-primary)" }}>{t.svcTitle}</h2>
+          </div>
+          <div className="max-w-xs font-light text-xs leading-relaxed text-left md:text-right font-mono uppercase tracking-wider" style={{ color: "var(--color-text-muted)" }}>{t.svcSubtitle}</div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8">
+          {SERVICES.map((service, idx) => (
+            <motion.div
+              key={service.id}
+              initial={{ opacity: 0, y: 40 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-100px" }}
+              transition={{ duration: 0.8, delay: (idx % 2) * 0.1, cubicBezier: [0.16, 1, 0.3, 1] }}
+              className="glass-panel glass-panel-hover rounded-2xl p-7 md:p-8 flex flex-col text-left relative overflow-hidden"
+            >
+              <div className="flex items-start justify-between mb-5">
+                <div className="w-12 h-12 rounded-xl flex items-center justify-center transition-all" style={{ border: "1px solid var(--color-border-primary)", backgroundColor: "var(--color-bg-card)", color: "var(--color-text-primary)" }}>
+                  {renderServiceIcon(service.icon, "w-6 h-6")}
+                </div>
+                <span className="font-mono text-[10px] uppercase tracking-widest select-none" style={{ color: "var(--color-text-dim)" }}>0{idx + 1}</span>
+              </div>
+
+              <h3 className="text-2xl font-display font-black tracking-tight mb-2" style={{ color: "var(--color-text-primary)" }}>{lang === "id" && service.titleId ? service.titleId : service.title}</h3>
+              <p className="font-light text-sm leading-relaxed mb-5" style={{ color: "var(--color-text-muted)" }}>{lang === "id" && service.descriptionId ? service.descriptionId : service.description}</p>
+
+              {service.examples && service.examples.length > 0 && (
+                <div className="mb-5">
+                  <span className="block font-mono text-[9px] tracking-[0.2em] uppercase mb-2" style={{ color: "var(--color-text-dim)" }}>{t.svcExamples}</span>
+                  <div className="flex flex-wrap gap-1.5">
+                    {service.examples.map((ex) => {
+                      const label = lang === "id" && ex.labelId ? ex.labelId : ex.label;
+                      return ex.url ? (
+                        <a key={ex.label} href={ex.url} target="_blank" rel="noopener noreferrer" className="text-[10px] font-mono px-2.5 py-0.5 rounded-full transition-colors flex items-center gap-1 group cursor-pointer" style={{ border: "1px solid var(--color-border-primary)", color: "var(--color-text-muted)" }} data-cursor="button">
+                          {label}
+                          <ExternalLink className="w-2.5 h-2.5 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform" />
+                        </a>
+                      ) : (
+                        <span key={ex.label} className="text-[10px] font-mono px-2.5 py-0.5 rounded-full" style={{ border: "1px solid var(--color-border-primary)", color: "var(--color-text-muted)" }}>{label}</span>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              <div className="mt-auto pt-4" style={{ borderTop: "1px solid var(--color-border-primary)" }}>
+                <span className="font-mono text-[11px] uppercase tracking-wider" style={{ color: "var(--color-text-secondary)" }}>{lang === "id" && service.outcomeId ? service.outcomeId : service.outcome}</span>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Social proof strip */}
+        <div className="mt-12 glass-panel rounded-2xl p-7 md:p-8 flex flex-col md:flex-row md:items-center justify-between gap-6">
+          <div className="text-left">
+            <h4 className="text-xs font-mono tracking-wider uppercase mb-1" style={{ color: "var(--color-text-muted)" }}>{t.svcProofTitle}</h4>
+            <p className="font-light text-sm leading-relaxed max-w-sm" style={{ color: "var(--color-text-muted)" }}>{t.svcProofDesc}</p>
+          </div>
+          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-8">
+            <div className="flex flex-wrap gap-x-6 gap-y-2">
+              {proofStats.map((stat) => (
+                <div key={stat.label} className="text-left">
+                  <span className="font-display font-extrabold text-xl tracking-tighter" style={{ color: "var(--color-text-primary)" }}>{stat.value}</span>
+                  <span className="block text-[10px] font-mono uppercase tracking-wider leading-tight" style={{ color: "var(--color-text-muted)" }}>{stat.label}</span>
+                </div>
+              ))}
+            </div>
+            <a href={LINKEDIN_URL} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 px-4 py-2.5 rounded-full text-xs font-mono tracking-wider transition-all cursor-pointer group" style={{ border: "1px solid var(--color-border-primary)", color: "var(--color-text-primary)" }} data-cursor="button">
+              <Linkedin className="w-4 h-4" />
+              {t.svcLinkedinRecs}
+              <ArrowUpRight className="w-3.5 h-3.5 group-hover:translate-x-1 group-hover:-translate-y-1 transition-transform" />
+            </a>
+          </div>
+        </div>
+
+        {/* CTA band */}
+        <div className="mt-8 rounded-2xl p-8 md:p-12 text-center relative overflow-hidden" style={{ backgroundColor: "var(--color-bg-secondary)", border: "1px solid var(--color-border-primary)" }}>
+          <h3 className="font-display font-black text-3xl md:text-4xl lg:text-5xl tracking-tight leading-tight" style={{ color: "var(--color-text-primary)" }}>{t.svcCtaTitle}</h3>
+          <p className="font-light text-sm md:text-base leading-relaxed mt-3 mb-7" style={{ color: "var(--color-text-muted)" }}>{t.svcCtaDesc}</p>
+          <button onClick={scrollToContact} className="px-7 py-3.5 rounded-full font-bold text-xs font-mono tracking-widest transition-colors flex items-center justify-center gap-2 mx-auto cursor-pointer select-none" style={{ backgroundColor: "var(--color-text-primary)", color: "var(--color-bg-primary)" }} data-cursor="button">
+            {t.svcCtaButton}
+            <ArrowUpRight className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,4 @@
-import { Experience, Project, SkillCategory, StatItem } from "./types";
+import { Experience, Project, Service, SkillCategory, StatItem } from "./types";
 import portraitImg from "./assets/images/jessen-portrait-removed-bg.webp";
 import tc00 from "./assets/images/tripcore-images/split_0_0.webp";
 import tc01 from "./assets/images/tripcore-images/split_0_1.webp";
@@ -17,6 +17,8 @@ const soulsyncLive = "/screenshots/soulsync-live.jpg";
 export const PORTRAIT_IMAGE = portraitImg;
 export const TRIPCORE_IMAGES = [tc00, tc01, tc10, tc11, tc20, tc21];
 export const SOULSYNC_IMAGES = [ss00, ss01, ss10];
+
+export const LINKEDIN_URL = "https://www.linkedin.com/in/jessenreinhart";
 
 export const STATS: StatItem[] = [
   { value: "7", label: "Years Experience", numericVal: 7 },
@@ -266,6 +268,63 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
       "Banking Systems Architecture",
       "Lighthouse Auditing",
       "White-label Modules"
+    ]
+  }
+];
+
+export const SERVICES: Service[] = [
+  {
+    id: "svc-website",
+    title: "Company Website / Landing Page",
+    titleId: "Website Perusahaan / Landing Page",
+    description: "A clean, fast site that gets your business online and makes it easy for people to reach you.",
+    descriptionId: "Situs cepat dan modern yang memudahkan pengunjung untuk menghubungi atau membeli.",
+    outcome: "Fast, modern site delivered in 1–2 weeks.",
+    outcomeId: "Situs cepat & modern siap dalam 1–2 minggu.",
+    icon: "website",
+    examples: [
+      { label: "Wedding E-Invitation", labelId: "Undangan Pernikahan Digital", url: "https://wedding-invitation-tau-two.vercel.app" },
+      { label: "This Portfolio", labelId: "Portofolio Ini", url: "https://github.com/JessenReinhart/jessenreinhart.github.io" }
+    ]
+  },
+  {
+    id: "svc-webapp",
+    title: "Web App (Booking, Ordering, Dashboard)",
+    titleId: "Web App (Booking, Order, Dashboard)",
+    description: "Custom apps built around how you work, like booking and ordering systems.",
+    descriptionId: "Aplikasi custom sesuai cara Anda bekerja, seperti sistem booking dan order.",
+    outcome: "Booking system, internal tool, or custom app.",
+    outcomeId: "Sistem booking, alat internal, atau aplikasi custom.",
+    icon: "webapp",
+    examples: [
+      { label: "TripCore", labelId: "TripCore", url: "https://tripcore-beta.vercel.app" },
+      { label: "Invoicr", labelId: "Invoicr", url: "https://invoicr-eight.vercel.app" }
+    ]
+  },
+  {
+    id: "svc-redesign",
+    title: "Frontend Upgrade / Redesign",
+    titleId: "Upgrade / Redesign Frontend",
+    description: "Modernize an old site with faster loads and a cleaner mobile layout.",
+    descriptionId: "Membuat situs lama menjadi lebih cepat dengan muat yang kencang dan tampilan mobile yang rapi.",
+    outcome: "Make your site fast & mobile-friendly.",
+    outcomeId: "Membuat situs Anda cepat & mobile-friendly.",
+    icon: "redesign",
+    examples: [
+      { label: "SIRCLO (Lighthouse 70→95)", labelId: "SIRCLO (Lighthouse 70→95)" }
+    ]
+  },
+  {
+    id: "svc-maintenance",
+    title: "Maintenance / Ongoing Support",
+    titleId: "Maintenance / Dukungan Berkelanjutan",
+    description: "I keep your site running with updates and monitoring each month.",
+    descriptionId: "Saya menjaga situs Anda tetap berjalan dengan pembaruan dan pemantauan setiap bulan.",
+    outcome: "Updates & monitoring every month.",
+    outcomeId: "Pembaruan & pemantauan setiap bulan.",
+    icon: "maintenance",
+    examples: [
+      { label: "Monthly care plans", labelId: "Paket perawatan bulanan" }
     ]
   }
 ];

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -8,6 +8,7 @@ export const translations = {
     navSkills: "SKILLS",
     navGithub: "GITHUB",
     navContact: "CONTACT",
+    navServices: "SERVICES",
     navGetInTouch: "GET IN TOUCH",
     navAvailable: "Available for contracts & full-time roles",
 
@@ -37,6 +38,18 @@ export const translations = {
     aboutP1: "I build the interfaces behind banking platforms, merchant dashboards, and content systems. The kind of software where slow load times or broken layouts mean real people can't do their jobs. I focus on making those interfaces load fast, work reliably, and stay maintainable as teams and features grow.",
     aboutP2: "My work ranges from tuning page load performance to structuring codebases so new features don't break old ones. I care about the details: server-rendered pages that load in under a second, TypeScript configs that catch bugs before they ship, and components that work across different brands and languages.",
     aboutSpecializations: "SPECIALIZATIONS",
+
+    // Services
+    svcSection: "02 // SERVICES",
+    svcTitle: "What I Can Build For You",
+    svcSubtitle: "PRACTICAL WEB WORK FOR SMALL TEAMS & BUSINESSES.",
+    svcProofTitle: "Trusted track record",
+    svcProofDesc: "Shipped to production for 30M users.",
+    svcLinkedinRecs: "Read LinkedIn recommendations",
+    svcExamples: "EXAMPLES",
+    svcCtaTitle: "Got a website or app idea?",
+    svcCtaDesc: "Want a free 15-min chat to talk it through?",
+    svcCtaButton: "Book a free 15-min call",
     aboutTechFocus: "TECHNICAL FOCUS",
     aboutSpec1: "React & Next.js Frameworks",
     aboutSpec2: "Enterprise Software Systems",
@@ -55,14 +68,14 @@ export const translations = {
     statOrders: "Monthly Orders",
 
     // Experience
-    expSection: "02 // PROFESSIONAL JOURNEY",
+    expSection: "03 // PROFESSIONAL JOURNEY",
     expTitle: "Professional Experience",
     expSubtitle: "Five roles, each building on the last. From library dashboards to platforms serving 30 million users.",
     expRoleDetails: "ROLE DETAILS",
     expStackDeployed: "STACK DEPLOYED",
 
     // Projects
-    projSection: "03 // SELECTED PROJECTS",
+    projSection: "04 // SELECTED PROJECTS",
     projTitle: "Selected Projects",
     projSubtitle: "Things I built to solve real problems I had.",
     projWhyBuilt: "WHY I BUILT THIS",
@@ -74,7 +87,7 @@ export const translations = {
     projCode: "CODE",
 
     // Skills
-    skillsSection: "04 // CAPABILITIES MATRIX",
+    skillsSection: "05 // CAPABILITIES MATRIX",
     skillsTitle: "Technical Skills",
     skillsSubtitle: "Core technologies, programming languages, and development frameworks used across systems.",
     catFrontend: "Frontend",
@@ -82,7 +95,7 @@ export const translations = {
     catEngineering: "Engineering Concepts",
 
     // Contact
-    contactSection: "06 // GET IN TOUCH",
+    contactSection: "07 // GET IN TOUCH",
     contactTitle: "Let's work together.",
     contactDesc: "Web application development, CMS solutions, or contract consulting.",
     contactEmail: "Direct Email",
@@ -104,7 +117,7 @@ export const translations = {
     contactSendAnother: "SEND ANOTHER MESSAGE",
 
     // GitHub
-    ghSection: "05 // OPEN SOURCE ACTIVITY",
+    ghSection: "06 // OPEN SOURCE ACTIVITY",
     ghTitle: "GitHub Activity",
     ghContributions: "contributions in the last 6 months",
     ghViewProfile: "VIEW PROFILE",
@@ -127,6 +140,7 @@ export const translations = {
     navSkills: "SKILL",
     navGithub: "GITHUB",
     navContact: "KONTAK",
+    navServices: "LAYANAN",
     navGetInTouch: "HUBUNGI SAYA",
     navAvailable: "Tersedia untuk kontrak & full-time",
 
@@ -156,6 +170,18 @@ export const translations = {
     aboutP1: "Saya membangun antarmuka di balik platform perbankan, dashboard merchant, dan sistem konten. Jenis perangkat lunak di mana waktu muat yang lambat atau tata letak yang rusak berarti orang sungguhan tidak bisa melakukan pekerjaan mereka. Saya fokus membuat antarmuka tersebut cepat dimuat, berjalan andal, dan tetap mudah dirawat seiring pertumbuhan tim dan fitur.",
     aboutP2: "Pekerjaan saya mencakup pengoptimalan waktu muat halaman hingga menata basis kode agar fitur baru tidak merusak yang lama. Saya peduli pada detail: halaman server-rendered yang dimuat dalam hitungan detik, konfigurasi TypeScript yang menangkap bug sebelum rilis, dan komponen yang bekerja lintas merek dan bahasa.",
     aboutSpecializations: "SPESIALISASI",
+
+    // Services
+    svcSection: "02 // LAYANAN",
+    svcTitle: "Yang Bisa Saya Buat Untuk Anda",
+    svcSubtitle: "LAYANAN WEB UNTUK TIM KECIL & BISNIS.",
+    svcProofTitle: "Rekam jejak terpercaya",
+    svcProofDesc: "Telah digunakan 30 juta pengguna di 20 bank, bukan sekadar demo.",
+    svcLinkedinRecs: "Baca rekomendasi LinkedIn",
+    svcExamples: "CONTOH",
+    svcCtaTitle: "Punya ide website/app?",
+    svcCtaDesc: "Mau konsultasi gratis 15 menit untuk membahas ide Anda?",
+    svcCtaButton: "Pesan konsultasi 15 menit gratis",
     aboutTechFocus: "FOKUS TEKNIS",
     aboutSpec1: "React & Next.js",
     aboutSpec2: "Software Enterprise",
@@ -174,14 +200,14 @@ export const translations = {
     statOrders: "Order Bulanan",
 
     // Experience
-    expSection: "02 // PERJALANAN PROFESIONAL",
+    expSection: "03 // PERJALANAN PROFESIONAL",
     expTitle: "Pengalaman Profesional",
     expSubtitle: "Lima peran, masing-masing dibangun dari yang sebelumnya. Dari dashboard perpustakaan hingga platform yang melayani 30 juta pengguna.",
     expRoleDetails: "DETAIL PERAN",
     expStackDeployed: "STACK DIGUNAKAN",
 
     // Projects
-    projSection: "03 // PROYEK PILIHAN",
+    projSection: "04 // PROYEK PILIHAN",
     projTitle: "Proyek Pilihan",
     projSubtitle: "Hal-hal yang saya buat untuk memecahkan masalah nyata.",
     projWhyBuilt: "MENGAPA SAYA MEMBUAT INI",
@@ -193,7 +219,7 @@ export const translations = {
     projMore: "lainnya",
 
     // Skills
-    skillsSection: "04 // KEMAMPUAN TEKNIS",
+    skillsSection: "05 // KEMAMPUAN TEKNIS",
     skillsTitle: "Skill Teknis",
     skillsSubtitle: "Teknologi inti, bahasa pemrograman, dan framework pengembangan yang digunakan di berbagai sistem.",
     catFrontend: "Frontend",
@@ -201,7 +227,7 @@ export const translations = {
     catEngineering: "Konsep Engineering",
 
     // Contact
-    contactSection: "06 // HUBUNGI SAYA",
+    contactSection: "07 // HUBUNGI SAYA",
     contactTitle: "Ayo bekerja sama.",
     contactDesc: "Pengembangan aplikasi web, solusi CMS, atau konsultasi.",
     contactEmail: "Email Langsung",
@@ -223,7 +249,7 @@ export const translations = {
     contactSendAnother: "KIRIM PESAN LAGI",
 
     // GitHub
-    ghSection: "05 // AKTIVITAS OPEN SOURCE",
+    ghSection: "06 // AKTIVITAS OPEN SOURCE",
     ghTitle: "Aktivitas GitHub",
     ghContributions: "kontribusi dalam 6 bulan terakhir",
     ghViewProfile: "LIHAT PROFIL",

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,3 +40,21 @@ export interface StatItem {
   numericVal: number;
   source?: string;
 }
+
+export interface ServiceExample {
+  label: string;
+  labelId?: string;
+  url?: string;
+}
+
+export interface Service {
+  id: string;
+  title: string;
+  titleId?: string;
+  description: string;
+  descriptionId?: string;
+  outcome: string;
+  outcomeId?: string;
+  icon: "website" | "webapp" | "redesign" | "maintenance";
+  examples?: ServiceExample[];
+}


### PR DESCRIPTION
Client-facing Services section after About: 4 offerings (website, web app, redesign, maintenance) with side-project examples, employment-stats + LinkedIn social proof, and a free-consult CTA. Copy audited against stop-slop taxonomy (no em-dashes/adverbs/binary contrasts) and written in proper Bahasa Indonesia.